### PR TITLE
[FEAT] 최신 뉴스 5개 반환 api 구현

### DIFF
--- a/U2E/build.gradle
+++ b/U2E/build.gradle
@@ -25,7 +25,6 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -36,7 +35,6 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/controller/NewsController.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/controller/NewsController.java
@@ -1,0 +1,22 @@
+package Konkuk.U2E.domain.news.controller;
+
+import Konkuk.U2E.domain.news.dto.response.GetLatelyNewsResponse;
+import Konkuk.U2E.domain.news.service.NewsLatelyService;
+import Konkuk.U2E.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/news")
+@RequiredArgsConstructor
+public class NewsController {
+
+    private final NewsLatelyService newsLatelyService;
+
+    @GetMapping("/lately")
+    public BaseResponse<GetLatelyNewsResponse> viewLatelyNewsList() {
+        return newsLatelyService.getLatelyNews();
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/GetLatelyNewsResponse.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/GetLatelyNewsResponse.java
@@ -1,0 +1,11 @@
+package Konkuk.U2E.domain.news.dto.response;
+
+import java.util.List;
+
+public record GetLatelyNewsResponse(
+        List<LatelyNews> latelyNewsList
+) {
+    public static GetLatelyNewsResponse of(List<LatelyNews> latelyNewsList) {
+        return new GetLatelyNewsResponse(latelyNewsList);
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/LatelyNews.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/LatelyNews.java
@@ -1,0 +1,19 @@
+package Konkuk.U2E.domain.news.dto.response;
+
+import java.util.List;
+
+public record LatelyNews(
+        Long newsId,
+        List<String> regionList,
+        List<String> climateList,
+        String newsTitle
+) {
+    public static LatelyNews of(Long newsId, List<String> regionList, List<String> climateList, String newsTitle) {
+        return new LatelyNews(
+                newsId,
+                regionList,
+                climateList,
+                newsTitle
+        );
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/repository/ClimateRepository.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/repository/ClimateRepository.java
@@ -1,9 +1,13 @@
 package Konkuk.U2E.domain.news.repository;
 
 import Konkuk.U2E.domain.news.domain.Climate;
+import Konkuk.U2E.domain.news.domain.News;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ClimateRepository extends JpaRepository<Climate, Long> {
+    List<Climate> findClimatesByNews(News news);
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/repository/NewsPinRepository.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/repository/NewsPinRepository.java
@@ -12,6 +12,6 @@ import java.util.List;
 public interface NewsPinRepository extends JpaRepository<NewsPin, Long> {
     @Query("SELECT p.region.name FROM NewsPin np " +
             "JOIN np.pin p " +
-            "WHERE np.pin.pinId = p.pinId AND np.news.newsId = :newsId")
+            "WHERE np.news.newsId = :newsId")
     List<String> findRegionNameByNews(@Param("newsId") Long newsId);
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/repository/NewsPinRepository.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/repository/NewsPinRepository.java
@@ -2,8 +2,16 @@ package Konkuk.U2E.domain.news.repository;
 
 import Konkuk.U2E.domain.news.domain.NewsPin;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface NewsPinRepository extends JpaRepository<NewsPin, Long> {
+    @Query("SELECT p.region.name FROM NewsPin np " +
+            "JOIN np.pin p " +
+            "WHERE np.pin.pinId = p.pinId AND np.news.newsId = :newsId")
+    List<String> findRegionNameByNews(@Param("newsId") Long newsId);
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/repository/NewsRepository.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/repository/NewsRepository.java
@@ -4,6 +4,9 @@ import Konkuk.U2E.domain.news.domain.News;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NewsRepository extends JpaRepository<News, Long> {
+    List<News> findTop5ByOrderByNewsDateDesc();
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsLatelyService.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsLatelyService.java
@@ -1,0 +1,41 @@
+package Konkuk.U2E.domain.news.service;
+
+import Konkuk.U2E.domain.news.domain.Climate;
+import Konkuk.U2E.domain.news.domain.ClimateProblem;
+import Konkuk.U2E.domain.news.dto.response.GetLatelyNewsResponse;
+import Konkuk.U2E.domain.news.dto.response.LatelyNews;
+import Konkuk.U2E.domain.news.repository.ClimateRepository;
+import Konkuk.U2E.domain.news.repository.NewsPinRepository;
+import Konkuk.U2E.domain.news.repository.NewsRepository;
+import Konkuk.U2E.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NewsLatelyService {
+
+    private final NewsRepository newsRepository;
+    private final ClimateRepository climateRepository;
+    private final NewsPinRepository newsPinRepository;
+
+    //news의 최신 뉴스 5개를 가져오는 서비스
+    public BaseResponse<GetLatelyNewsResponse> getLatelyNews() {
+
+        return BaseResponse.ok(GetLatelyNewsResponse.of(newsRepository.findTop5ByOrderByNewsDateDesc().stream()
+                .map((latelyNews) -> {
+                    List<String> regionNameByNews = newsPinRepository.findRegionNameByNews(latelyNews.getNewsId());
+
+                    List<String> climateProblems = climateRepository.findClimatesByNews(latelyNews).stream()
+                            .map(Climate::getClimateProblem)
+                            .map(ClimateProblem::getClimateProblem)
+                            .toList();
+
+                    return LatelyNews.of(latelyNews.getNewsId(), regionNameByNews, climateProblems, latelyNews.getNewsTitle());
+                }).toList())
+        );
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #9 

## 📝작업 내용
<img width="135" alt="스크린샷 2025-05-03 오후 6 28 21" src="https://github.com/user-attachments/assets/c481d39c-c0f7-4ade-a7d8-63502a38420e" />

- 최신 뉴스 5개를 개발하는 api를 구현하였습니다.
- 각 뉴스마다 지역도 여러개, 기후 문제도 여러개 가지고 있으므로 regionList와 climateList를 반환하게끔 하였습니다. 

### 스크린샷 
<img width="847" alt="스크린샷 2025-05-03 오후 6 23 12" src="https://github.com/user-attachments/assets/05068af8-ca3b-4a9a-95df-ede2574565bd" />

## 💬추가사항

> spring security 의존성도 제거하였습니다.
>
