### PR TITLE
[FEAT] 뉴스 상세보기 api 구현

### DIFF
--- a/U2E/src/main/java/Konkuk/U2E/domain/news/controller/NewsController.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/controller/NewsController.java
@@ -1,10 +1,13 @@
 package Konkuk.U2E.domain.news.controller;
 
 import Konkuk.U2E.domain.news.dto.response.GetLatelyNewsResponse;
+import Konkuk.U2E.domain.news.dto.response.GetNewsInfoResponse;
+import Konkuk.U2E.domain.news.service.NewsInfoService;
 import Konkuk.U2E.domain.news.service.NewsLatelyService;
 import Konkuk.U2E.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,9 +17,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class NewsController {
 
     private final NewsLatelyService newsLatelyService;
+    private final NewsInfoService newsInfoService;
 
     @GetMapping("/lately")
     public BaseResponse<GetLatelyNewsResponse> viewLatelyNewsList() {
         return newsLatelyService.getLatelyNews();
+    }
+
+    @GetMapping("/{newsId}")
+    public BaseResponse<GetNewsInfoResponse> viewNewsInfo(@PathVariable("newsId") final Long newsId) {
+        return newsInfoService.getNewsInfo(newsId);
     }
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/GetNewsInfoResponse.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/GetNewsInfoResponse.java
@@ -1,0 +1,21 @@
+package Konkuk.U2E.domain.news.dto.response;
+
+import Konkuk.U2E.domain.news.domain.Climate;
+import Konkuk.U2E.domain.news.domain.ClimateProblem;
+import Konkuk.U2E.domain.news.domain.News;
+
+import java.util.List;
+
+public record GetNewsInfoResponse(
+        List<ClimateProblem> climateList,
+        List<String> regionList,
+        String newsTitle,
+        String newsUrl,
+        String newsImageUrl,
+        String newsBody,
+        String newsDate
+) {
+    public static GetNewsInfoResponse of(List<ClimateProblem> climateList, List<String> regionList, News news) {
+        return new GetNewsInfoResponse(climateList, regionList, news.getNewsTitle(), news.getNewsUrl(), news.getImageUrl(), news.getNewsBody(), news.getNewsDate().toString());
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/GetNewsInfoResponse.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/GetNewsInfoResponse.java
@@ -3,6 +3,7 @@ package Konkuk.U2E.domain.news.dto.response;
 import Konkuk.U2E.domain.news.domain.Climate;
 import Konkuk.U2E.domain.news.domain.ClimateProblem;
 import Konkuk.U2E.domain.news.domain.News;
+import Konkuk.U2E.domain.news.service.mapper.NewsMappingResult;
 
 import java.util.List;
 
@@ -15,7 +16,8 @@ public record GetNewsInfoResponse(
         String newsBody,
         String newsDate
 ) {
-    public static GetNewsInfoResponse of(List<ClimateProblem> climateList, List<String> regionList, News news) {
-        return new GetNewsInfoResponse(climateList, regionList, news.getNewsTitle(), news.getNewsUrl(), news.getImageUrl(), news.getNewsBody(), news.getNewsDate().toString());
+    public static GetNewsInfoResponse of(NewsMappingResult newsMappingResult) {
+        News news = newsMappingResult.news();
+        return new GetNewsInfoResponse(newsMappingResult.climateProblems(), newsMappingResult.regionNames(), news.getNewsTitle(), news.getNewsUrl(), news.getImageUrl(), news.getNewsBody(), news.getNewsDate().toString());
     }
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/LatelyNews.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/LatelyNews.java
@@ -1,19 +1,22 @@
 package Konkuk.U2E.domain.news.dto.response;
 
+import Konkuk.U2E.domain.news.domain.ClimateProblem;
+import Konkuk.U2E.domain.news.domain.News;
+
 import java.util.List;
 
 public record LatelyNews(
         Long newsId,
         List<String> regionList,
-        List<String> climateList,
+        List<ClimateProblem> climateList,
         String newsTitle
 ) {
-    public static LatelyNews of(Long newsId, List<String> regionList, List<String> climateList, String newsTitle) {
+    public static LatelyNews of(List<ClimateProblem> climateList, List<String> regionList, News news) {
         return new LatelyNews(
-                newsId,
+                news.getNewsId(),
                 regionList,
                 climateList,
-                newsTitle
+                news.getNewsTitle()
         );
     }
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/LatelyNews.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/dto/response/LatelyNews.java
@@ -2,6 +2,7 @@ package Konkuk.U2E.domain.news.dto.response;
 
 import Konkuk.U2E.domain.news.domain.ClimateProblem;
 import Konkuk.U2E.domain.news.domain.News;
+import Konkuk.U2E.domain.news.service.mapper.NewsMappingResult;
 
 import java.util.List;
 
@@ -11,11 +12,12 @@ public record LatelyNews(
         List<ClimateProblem> climateList,
         String newsTitle
 ) {
-    public static LatelyNews of(List<ClimateProblem> climateList, List<String> regionList, News news) {
+    public static LatelyNews of(NewsMappingResult newsMappingResult) {
+        News news = newsMappingResult.news();
         return new LatelyNews(
                 news.getNewsId(),
-                regionList,
-                climateList,
+                newsMappingResult.regionNames(),
+                newsMappingResult.climateProblems(),
                 news.getNewsTitle()
         );
     }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/exception/NewsNotFoundException.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/exception/NewsNotFoundException.java
@@ -1,0 +1,15 @@
+package Konkuk.U2E.domain.news.exception;
+
+import Konkuk.U2E.global.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class NewsNotFoundException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public NewsNotFoundException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/exception/handler/NewsControllerAdvice.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/exception/handler/NewsControllerAdvice.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import static Konkuk.U2E.global.response.status.BaseExceptionResponseStatus.BAD_REQUEST;
+import static Konkuk.U2E.global.response.status.BaseExceptionResponseStatus.NEWS_NOT_FOUND;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @Slf4j

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/exception/handler/NewsControllerAdvice.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/exception/handler/NewsControllerAdvice.java
@@ -1,0 +1,26 @@
+package Konkuk.U2E.domain.news.exception.handler;
+
+import Konkuk.U2E.domain.news.exception.NewsNotFoundException;
+import Konkuk.U2E.global.response.BaseErrorResponse;
+import Konkuk.U2E.global.response.status.BaseExceptionResponseStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static Konkuk.U2E.global.response.status.BaseExceptionResponseStatus.BAD_REQUEST;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Slf4j
+@RestControllerAdvice(basePackages = "Konkuk.U2E.domain.news")
+public class NewsControllerAdvice {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(NewsNotFoundException.class)
+    public BaseErrorResponse handle_NewsNotFoundException(NewsNotFoundException e) {
+        log.error("[handle_NewsNotFoundException]", e);
+        return new BaseErrorResponse(BAD_REQUEST, e.getMessage());
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/exception/handler/NewsControllerAdvice.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/exception/handler/NewsControllerAdvice.java
@@ -21,6 +21,6 @@ public class NewsControllerAdvice {
     @ExceptionHandler(NewsNotFoundException.class)
     public BaseErrorResponse handle_NewsNotFoundException(NewsNotFoundException e) {
         log.error("[handle_NewsNotFoundException]", e);
-        return new BaseErrorResponse(BAD_REQUEST, e.getMessage());
+        return new BaseErrorResponse(NEWS_NOT_FOUND, e.getMessage());
     }
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsInfoService.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsInfoService.java
@@ -1,18 +1,13 @@
 package Konkuk.U2E.domain.news.service;
 
-import Konkuk.U2E.domain.news.domain.Climate;
-import Konkuk.U2E.domain.news.domain.ClimateProblem;
 import Konkuk.U2E.domain.news.domain.News;
 import Konkuk.U2E.domain.news.dto.response.GetNewsInfoResponse;
 import Konkuk.U2E.domain.news.exception.NewsNotFoundException;
-import Konkuk.U2E.domain.news.repository.ClimateRepository;
-import Konkuk.U2E.domain.news.repository.NewsPinRepository;
 import Konkuk.U2E.domain.news.repository.NewsRepository;
+import Konkuk.U2E.domain.news.service.mapper.NewsMapperFactory;
 import Konkuk.U2E.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 import static Konkuk.U2E.global.response.status.BaseExceptionResponseStatus.NEWS_NOT_FOUND;
 
@@ -21,20 +16,13 @@ import static Konkuk.U2E.global.response.status.BaseExceptionResponseStatus.NEWS
 public class NewsInfoService {
 
     private final NewsRepository newsRepository;
-    private final ClimateRepository climateRepository;
-    private final NewsPinRepository newsPinRepository;
+    private final NewsMapperFactory newsMapperFactory;
 
+    // 뉴스 상세보기
     public BaseResponse<GetNewsInfoResponse> getNewsInfo(Long newsId) {
-
         News news = newsRepository.findById(newsId)
                 .orElseThrow(() -> new NewsNotFoundException(NEWS_NOT_FOUND));
 
-        List<String> regionNameByNews = newsPinRepository.findRegionNameByNews(news.getNewsId());
-
-        List<ClimateProblem> climateProblems = climateRepository.findClimatesByNews(news).stream()
-                .map(Climate::getClimateProblem)
-                .toList();
-
-        return BaseResponse.ok(GetNewsInfoResponse.of(climateProblems, regionNameByNews, news));
+        return BaseResponse.ok(GetNewsInfoResponse.of(newsMapperFactory.newsMappingFunction().apply(news)));
     }
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsInfoService.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsInfoService.java
@@ -1,0 +1,40 @@
+package Konkuk.U2E.domain.news.service;
+
+import Konkuk.U2E.domain.news.domain.Climate;
+import Konkuk.U2E.domain.news.domain.ClimateProblem;
+import Konkuk.U2E.domain.news.domain.News;
+import Konkuk.U2E.domain.news.dto.response.GetNewsInfoResponse;
+import Konkuk.U2E.domain.news.exception.NewsNotFoundException;
+import Konkuk.U2E.domain.news.repository.ClimateRepository;
+import Konkuk.U2E.domain.news.repository.NewsPinRepository;
+import Konkuk.U2E.domain.news.repository.NewsRepository;
+import Konkuk.U2E.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static Konkuk.U2E.global.response.status.BaseExceptionResponseStatus.NEWS_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class NewsInfoService {
+
+    private final NewsRepository newsRepository;
+    private final ClimateRepository climateRepository;
+    private final NewsPinRepository newsPinRepository;
+
+    public BaseResponse<GetNewsInfoResponse> getNewsInfo(Long newsId) {
+
+        News news = newsRepository.findById(newsId)
+                .orElseThrow(() -> new NewsNotFoundException(NEWS_NOT_FOUND));
+
+        List<String> regionNameByNews = newsPinRepository.findRegionNameByNews(news.getNewsId());
+
+        List<ClimateProblem> climateProblems = climateRepository.findClimatesByNews(news).stream()
+                .map(Climate::getClimateProblem)
+                .toList();
+
+        return BaseResponse.ok(GetNewsInfoResponse.of(climateProblems, regionNameByNews, news));
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsLatelyService.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsLatelyService.java
@@ -7,6 +7,7 @@ import Konkuk.U2E.domain.news.dto.response.LatelyNews;
 import Konkuk.U2E.domain.news.repository.ClimateRepository;
 import Konkuk.U2E.domain.news.repository.NewsPinRepository;
 import Konkuk.U2E.domain.news.repository.NewsRepository;
+import Konkuk.U2E.domain.news.service.mapper.NewsMapperFactory;
 import Konkuk.U2E.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,23 +19,14 @@ import java.util.List;
 public class NewsLatelyService {
 
     private final NewsRepository newsRepository;
-    private final ClimateRepository climateRepository;
-    private final NewsPinRepository newsPinRepository;
+    private final NewsMapperFactory newsMapperFactory;
 
     //news의 최신 뉴스 5개를 가져오는 서비스
     public BaseResponse<GetLatelyNewsResponse> getLatelyNews() {
-
         return BaseResponse.ok(GetLatelyNewsResponse.of(newsRepository.findTop5ByOrderByNewsDateDesc().stream()
-                .map((latelyNews) -> {
-                    List<String> regionNameByNews = newsPinRepository.findRegionNameByNews(latelyNews.getNewsId());
-
-                    List<ClimateProblem> climateProblems = climateRepository.findClimatesByNews(latelyNews).stream()
-                            .map(Climate::getClimateProblem)
-                            .toList();
-
-                    return LatelyNews.of(climateProblems, regionNameByNews, latelyNews);
-                }).toList())
+                .map(newsMapperFactory.newsMappingFunction())
+                .map(LatelyNews::of)
+                .toList())
         );
     }
-
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsLatelyService.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/service/NewsLatelyService.java
@@ -28,12 +28,11 @@ public class NewsLatelyService {
                 .map((latelyNews) -> {
                     List<String> regionNameByNews = newsPinRepository.findRegionNameByNews(latelyNews.getNewsId());
 
-                    List<String> climateProblems = climateRepository.findClimatesByNews(latelyNews).stream()
+                    List<ClimateProblem> climateProblems = climateRepository.findClimatesByNews(latelyNews).stream()
                             .map(Climate::getClimateProblem)
-                            .map(ClimateProblem::getClimateProblem)
                             .toList();
 
-                    return LatelyNews.of(latelyNews.getNewsId(), regionNameByNews, climateProblems, latelyNews.getNewsTitle());
+                    return LatelyNews.of(climateProblems, regionNameByNews, latelyNews);
                 }).toList())
         );
     }

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/service/mapper/NewsMapperFactory.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/service/mapper/NewsMapperFactory.java
@@ -1,0 +1,32 @@
+package Konkuk.U2E.domain.news.service.mapper;
+
+import Konkuk.U2E.domain.news.domain.Climate;
+import Konkuk.U2E.domain.news.domain.ClimateProblem;
+import Konkuk.U2E.domain.news.domain.News;
+import Konkuk.U2E.domain.news.repository.ClimateRepository;
+import Konkuk.U2E.domain.news.repository.NewsPinRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
+public class NewsMapperFactory {        //news -> 관련된 기후문제 리스트 & 관련된 지역 이름 리스트 & news 로 매핑해주는 함수형 인터페이스 생성
+
+    private final ClimateRepository climateRepository;
+    private final NewsPinRepository newsPinRepository;
+
+    public Function<News, NewsMappingResult> newsMappingFunction(
+    ) {
+        return news -> {
+            List<String> regionNames = newsPinRepository.findRegionNameByNews(news.getNewsId());
+            List<ClimateProblem> climateProblems = climateRepository.findClimatesByNews(news).stream()
+                    .map(Climate::getClimateProblem)
+                    .toList();
+
+            return new NewsMappingResult(climateProblems, regionNames, news);
+        };
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/domain/news/service/mapper/NewsMappingResult.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/service/mapper/NewsMappingResult.java
@@ -1,0 +1,12 @@
+package Konkuk.U2E.domain.news.service.mapper;
+
+import Konkuk.U2E.domain.news.domain.ClimateProblem;
+import Konkuk.U2E.domain.news.domain.News;
+
+import java.util.List;
+
+public record NewsMappingResult(
+        List<ClimateProblem> climateProblems,
+        List<String> regionNames,
+        News news
+) {}

--- a/U2E/src/main/java/Konkuk/U2E/global/config/initData/CommentUserInitializer.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/config/initData/CommentUserInitializer.java
@@ -1,4 +1,4 @@
-package Konkuk.U2E.config.initData;
+package Konkuk.U2E.global.config.initData;
 
 import Konkuk.U2E.domain.comment.domain.Comment;
 import Konkuk.U2E.domain.comment.repository.CommentRepository;

--- a/U2E/src/main/java/Konkuk/U2E/global/config/initData/DataLoader.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/config/initData/DataLoader.java
@@ -1,4 +1,4 @@
-package Konkuk.U2E.config.initData;
+package Konkuk.U2E.global.config.initData;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;

--- a/U2E/src/main/java/Konkuk/U2E/global/config/initData/NewsInitializer.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/config/initData/NewsInitializer.java
@@ -1,4 +1,4 @@
-package Konkuk.U2E.config.initData;
+package Konkuk.U2E.global.config.initData;
 
 import Konkuk.U2E.domain.news.domain.Climate;
 import Konkuk.U2E.domain.news.domain.ClimateProblem;

--- a/U2E/src/main/java/Konkuk/U2E/global/config/initData/RegionPinInitializer.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/config/initData/RegionPinInitializer.java
@@ -1,4 +1,4 @@
-package Konkuk.U2E.config.initData;
+package Konkuk.U2E.global.config.initData;
 
 import Konkuk.U2E.domain.news.domain.News;
 import Konkuk.U2E.domain.news.domain.NewsPin;

--- a/U2E/src/main/java/Konkuk/U2E/global/exception/BadRequestException.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/exception/BadRequestException.java
@@ -1,0 +1,15 @@
+package Konkuk.U2E.global.exception;
+
+import Konkuk.U2E.global.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public BadRequestException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/global/exception/handler/GlobalControllerAdvice.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/exception/handler/GlobalControllerAdvice.java
@@ -1,0 +1,48 @@
+package Konkuk.U2E.global.exception.handler;
+
+import Konkuk.U2E.global.exception.BadRequestException;
+import Konkuk.U2E.global.response.BaseErrorResponse;
+import Konkuk.U2E.global.response.status.BaseExceptionResponseStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.TypeMismatchException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import static Konkuk.U2E.global.response.status.BaseExceptionResponseStatus.*;
+
+@Order(Ordered.LOWEST_PRECEDENCE)
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+    // 잘못된 요청일 경우
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({BadRequestException.class, TypeMismatchException.class, MethodArgumentNotValidException.class, MissingServletRequestParameterException.class})
+    public BaseErrorResponse handle_BadRequest(Exception e){
+        log.error("[handle_BadRequest]", e);
+        return new BaseErrorResponse(BAD_REQUEST);
+    }
+
+    // 요청한 api가 없을 경우
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public BaseErrorResponse handle_NoHandlerFoundException(Exception e){
+        log.error("[handle_NoHandlerFoundException]", e);
+        return new BaseErrorResponse(NOT_FOUND);
+    }
+
+    // 런타임 오류가 발생한 경우
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(RuntimeException.class)
+    public BaseErrorResponse handle_RuntimeException(Exception e) {
+        log.error("[handle_RuntimeException]", e);
+        return new BaseErrorResponse(INTERNAL_SERVER_ERROR);
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/global/response/BaseErrorResponse.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/response/BaseErrorResponse.java
@@ -1,0 +1,41 @@
+package Konkuk.U2E.global.response;
+
+import Konkuk.U2E.global.response.status.ResponseStatus;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"success", "code", "message","data"})
+public class BaseErrorResponse implements ResponseStatus {
+    private final boolean success;
+    private final int code;
+    private final String message;
+    private final Object data;
+
+    public BaseErrorResponse(ResponseStatus status) {
+        this.success = false;
+        this.code = status.getCode();
+        this.message = status.getMessage();
+        this.data = null;
+    }
+
+    public BaseErrorResponse(ResponseStatus status, String message) {
+        this.success = false;
+        this.code = status.getCode();
+        this.message = message;
+        this.data = null;
+    }
+
+    @Override
+    public boolean getSuccess() {
+        return this.success;
+    }
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/global/response/BaseResponse.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/response/BaseResponse.java
@@ -1,57 +1,44 @@
 package Konkuk.U2E.global.response;
 
+import Konkuk.U2E.global.response.status.BaseExceptionResponseStatus;
 import Konkuk.U2E.global.response.status.ResponseStatus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import static Konkuk.U2E.global.response.status.BaseExceptionResponseStatus.SUCCESS;
+
 @Getter
-@JsonPropertyOrder({"code", "status", "message", "data"})
+@JsonPropertyOrder({"success", "code", "message", "data"})
 public class BaseResponse<T> implements ResponseStatus {
 
+    private final boolean success;
     private final int code;
-    private final HttpStatus status;
     private final String message;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T data;
 
-    public BaseResponse(HttpStatus status, String message, T data) {
-        this.code = status.value();
-        this.message = message;
-        this.status = status;
+    public BaseResponse(T data) {
+        this.success = true;
+        this.code = SUCCESS.getCode();
+        this.message = SUCCESS.getMessage();
         this.data = data;
     }
 
-    public static <T> BaseResponse<T> of(HttpStatus status, String message, T data) {
-        return new BaseResponse<>(status, message, data);
-    }
-
-    public static <T> BaseResponse<T> of(HttpStatus status, T data) {
-        return of(status, status.name(), data);
-    }
-
     public static <T> BaseResponse<T> ok(T data) {
-        return of(HttpStatus.OK, data);
+        return new BaseResponse<>(data);
     }
 
-    public static BaseResponse<Void> of(HttpStatus status) {
-        return new BaseResponse<>(status, status.name(), null);
-    }
-
-    public static BaseResponse<Void> ok() {
-        return of(HttpStatus.OK);
+    @Override
+    public boolean getSuccess() {
+        return success;
     }
 
     @Override
     public int getCode() {
         return code;
-    }
-
-    @Override
-    public HttpStatus getStatus() {
-        return status;
     }
 
     @Override

--- a/U2E/src/main/java/Konkuk/U2E/global/response/status/BaseExceptionResponseStatus.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/response/status/BaseExceptionResponseStatus.java
@@ -1,0 +1,36 @@
+package Konkuk.U2E.global.response.status;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum BaseExceptionResponseStatus implements ResponseStatus {
+
+    SUCCESS(20000, "요청에 성공했습니다."),
+    BAD_REQUEST(40000, "유효하지 않은 요청입니다."),
+    NOT_FOUND(40400, "존재하지 않는 API입니다."),
+
+    NEWS_NOT_FOUND(30000, "알맞은 뉴스를 찾을 수 없습니다."),
+
+    INTERNAL_SERVER_ERROR(50000, "서버 내부 오류입니다.")
+    ;
+
+    private final boolean success = false;
+    private final int code;
+    private final String message;
+
+    @Override
+    public boolean getSuccess() {
+        return success;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/U2E/src/main/java/Konkuk/U2E/global/response/status/ResponseStatus.java
+++ b/U2E/src/main/java/Konkuk/U2E/global/response/status/ResponseStatus.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public interface ResponseStatus {
 
+    boolean getSuccess();
     int getCode();
-    HttpStatus getStatus();
     String getMessage();
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #11 

## 📝작업 내용

- [x] 더미데이터 초기화 코드 패키지 이동 (global 아래로)
- [x] BaseResponse 수정
- [x] BaseErrorResponse 정의 및 에러 핸들러 추가
- [x] 최신 뉴스 조회 api에서 기후 문제를 Enum 그대로 반환하도록 수정
- [x] 뉴스 상세보기 api 구현
- [x] 최신 뉴스 조회 api와 뉴스 상세보기 api에서 공통 매핑 로직 추출

### 스크린샷 
**조회 성공 캡쳐**
<img width="847" alt="스크린샷 2025-05-05 오전 2 50 00" src="https://github.com/user-attachments/assets/077b9927-37e8-4492-beaa-67a5a21fb515" />

**조회 실패시 예외 캡쳐**
<img width="847" alt="스크린샷 2025-05-05 오전 2 57 18" src="https://github.com/user-attachments/assets/0c93f787-2353-41be-a8bc-4d5b95d1bf4f" />

## 💬리뷰 요구사항(선택)
- 전체적으로 응답 형식을 수정하였으니 꼼꼼하게 확인부탁드리겠습니다~
- 앞으로 에러 처리시에 제가 활용한 방식보고 하시면 됩니다. 각각의 핸들러와 예외는 호출 또는 생성되는 도메인 내부 패키지에 넣어주시면 감사하겠습니다!
