### PR TITLE
[REFACTOR] 기후로 핀 필터링할때 사용자가 요청한 기후가 아닌 News가 매핑되는 문제 해결

### DIFF
--- a/U2E/src/main/java/Konkuk/U2E/domain/news/repository/ClimateRepository.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/news/repository/ClimateRepository.java
@@ -16,4 +16,9 @@ public interface ClimateRepository extends JpaRepository<Climate, Long> {
 
     @Query("SELECT c.news FROM Climate c WHERE c.climateProblem = :climateProblem")
     List<News> findNewsByClimateProblem(@Param("climateProblem") ClimateProblem climateProblem);
+
+    @Query("SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END " +
+            "FROM Climate c WHERE c.news = :news AND c.climateProblem = :climateProblem")
+    boolean existsByNewsAndClimateProblem(@Param("news") News news,
+                                          @Param("climateProblem") ClimateProblem climateProblem);
 }

--- a/U2E/src/main/java/Konkuk/U2E/domain/pin/service/PinListService.java
+++ b/U2E/src/main/java/Konkuk/U2E/domain/pin/service/PinListService.java
@@ -77,7 +77,7 @@ public class PinListService {
         return climateRepository.findNewsByClimateProblem(climateProblem).stream()
                 .map(newsPinRepository::findPinsByNews)
                 .flatMap(pinList -> pinList.stream()
-                            .map(this::createPinInfo)
+                            .map(pin -> this.createPinInfo(pin, climateProblem))
                 ).distinct()
                 .toList();
     }
@@ -93,13 +93,31 @@ public class PinListService {
                 .toList();
     }
 
-    public PinInfo createPinInfo(Pin pin) {
+    private PinInfo createPinInfo(Pin pin) {
         List<News> newsList = newsPinRepository.findNewsByPinId(pin.getPinId());
         if (newsList.isEmpty()) {   // 뉴스가 없는 핀은 존재할 수 없으므로 예외처리
             throw new PinNewsNotFoundException(PINNEWS_NOT_FOUND);
         }
 
         News latestNews = dateUtil.getLatestNews(newsList);
+        boolean isLately = dateUtil.checkLately(latestNews.getNewsDate());
+
+        List<ClimateProblem> climateProblems = climateRepository.findClimatesByNews(latestNews).stream()
+                .map(Climate::getClimateProblem)
+                .toList();
+        return PinInfo.of(pin, pin.getRegion(), isLately, climateProblems);
+    }
+
+    private PinInfo createPinInfo(Pin pin, ClimateProblem climateProblem) {
+        List<News> newsList = newsPinRepository.findNewsByPinId(pin.getPinId());
+        if (newsList.isEmpty()) {   // 뉴스가 없는 핀은 존재할 수 없으므로 예외처리
+            throw new PinNewsNotFoundException(PINNEWS_NOT_FOUND);
+        }
+
+        News latestNews = dateUtil.getLatestNews(
+                newsList.stream()
+                .filter(news -> climateRepository.existsByNewsAndClimateProblem(news, climateProblem)).toList()     //사용자가 필터링을 요청한 ClimateProblem을 포함하지 않는 경우 제거
+        );
         boolean isLately = dateUtil.checkLately(latestNews.getNewsDate());
 
         List<ClimateProblem> climateProblems = climateRepository.findClimatesByNews(latestNews).stream()


### PR DESCRIPTION
## #️⃣연관된 이슈

-  closes #32 

## 📝작업 내용

- pin에서 매핑되어 있는 NewsList 중 최신 뉴스를 찾을 때 사용자가 필터링을 요청한 기후를 포함하지 않은 뉴스인 경우 필터링해서 제거되도록 수정하였습니다.

### 스크린샷 (선택)
현재 매핑 구조는 다음 사진과 같습니다. 마지막 뉴스 D가 사용자가 요청한 기후를 포함하지 않지만 최신 뉴스로 발탁되는 경우 사용자가 요청한 기후와 다른 기후를 가진 pin이 반환되는 결과가 발생합니다.
![image](https://github.com/user-attachments/assets/bb15eeb2-646d-4655-ba9d-db6b6c906ac1)

이를 pin에 매핑되어 있는 최신 뉴스를 찾는 createPinInfo 메서드를 오버로딩하여 수정했습니다.

```java
private PinInfo createPinInfo(Pin pin, ClimateProblem climateProblem) {
        List<News> newsList = newsPinRepository.findNewsByPinId(pin.getPinId());
        if (newsList.isEmpty()) {   // 뉴스가 없는 핀은 존재할 수 없으므로 예외처리
            throw new PinNewsNotFoundException(PINNEWS_NOT_FOUND);
        }

        News latestNews = dateUtil.getLatestNews(
                newsList.stream()
                .filter(news -> climateRepository.existsByNewsAndClimateProblem(news, climateProblem)).toList()     //사용자가 필터링을 요청한 ClimateProblem을 포함하지 않는 경우 제거
        );
        boolean isLately = dateUtil.checkLately(latestNews.getNewsDate());

        List<ClimateProblem> climateProblems = climateRepository.findClimatesByNews(latestNews).stream()
                .map(Climate::getClimateProblem)
                .toList();
        return PinInfo.of(pin, pin.getRegion(), isLately, climateProblems);
    }
```

결과적으로 사용자가 필터링 요청한 기후를 포함하는 Pin만 반환되는 것을 볼 수 있습니다.
<img width="847" alt="스크린샷 2025-05-14 오후 1 58 20" src="https://github.com/user-attachments/assets/1ad9e6f4-52d9-46ce-839c-6ee979cb4587" />

